### PR TITLE
fix: replace BOM when calc checksum

### DIFF
--- a/cambia-core/src/parser/eac_parser.rs
+++ b/cambia-core/src/parser/eac_parser.rs
@@ -442,6 +442,7 @@ impl IntegrityChecker for EacParserSingle {
         let checksum_stripped = CHECKSUM.replace_all(&self.log, "");
         let utf16data: Vec<u16> = checksum_stripped
                                         .replace(['\r', '\n'], "")
+                                        .replace(['\u{feff}', '\u{ffef}'], "")
                                         .encode_utf16()
                                         .collect();
         let mut utf16bytes = unsafe { utf16data.align_to::<u8>().1.to_vec() };


### PR DESCRIPTION
I have a log which checksum can pass EAC's `Checklog.exe` but can not pass in this repo.

After some reverse engine on `Checklog.exe`, I belive we should also replace all BOMs to empty when calculate EAC checksum. 

![image](https://github.com/user-attachments/assets/52e89d61-f510-425d-8d11-1eac12fa3217)

(Part of `HelperFunctions.dll`)

The log I've mentioned above:
[Static World, bunny_rhyTHm - 冰空夏日葵 -Frozen Sky Sunflower-.log](https://github.com/user-attachments/files/20118626/Static.World.bunny_rhyTHm.-.-Frozen.Sky.Sunflower-.log)
